### PR TITLE
Added PyPI (test) Packaging

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,9 +1,8 @@
 name: Publish Package to TestPyPI
 
-# do not run automitically until git workflow (developing on 'develop' branch) has been established
+# do not run automatically until git workflow (developing on 'develop' branch) has been established
 # on: push
 on: workflow_dispatch
-
 
 jobs:
   build-n-publish:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -2,6 +2,8 @@ name: Publish Package to TestPyPI
 
 # do not run automitically until git workflow (developing on 'develop' branch) has been established
 # on: push
+on: workflow_dispatch
+
 
 jobs:
   build-n-publish:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,37 @@
+name: Publish Package to TestPyPI
+
+# do not run automitically until git workflow (developing on 'develop' branch) has been established
+# on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish package to TestPyPI
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@main
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+
+    - name: Publish EAO to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_TEST_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,24 @@
+[metadata]
+name = eaopack
+version = 1.0.0
+author = Tobias Pfingsten, Daniel Oeltz
+author_email = which@email.com
+description = A Framework for Optimizing Decentralized Portfolios and Green Supply
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/EnergyAssetOptimization/EAO
+project_urls =
+    Bug Tracker = https://github.com/EnergyAssetOptimization/issues
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+
+[options]
+packages = find:
+python_requires = >=3.6
+
+[options.packages.find]
+exclude =
+    tests
+    doc


### PR DESCRIPTION
Die Konfiguration läuft jetzt erst mal gegen den PyPI-Testserver. Dafür habe ich einen Account mit dem Namen "EnergyAssetOptimization" erstellt. Die Github-Action muss manuell angestoßen werden. Optional können wir es irgendwann so umstellen, dass mit dem Merge nach Main automatisch pupliziert wird.

Schaut euch an ob die Konfiguration passt.
* Package name: 'eaopack' (eao ist leider schon vergeben)
* Die Liste der Emailadressen müsst Ihr definieren
 * Namen / Beschreibung könnt Ihr ggfls. noch anpassen

